### PR TITLE
Hide password from console.

### DIFF
--- a/lib/fastlane/plugin/altool/actions/altool_action.rb
+++ b/lib/fastlane/plugin/altool/actions/altool_action.rb
@@ -87,7 +87,7 @@ module Fastlane
                                     description: "Your Apple ID Password for iTunes Connects. This usually FASTLANE_PASSWORD environmental variable",
                                     is_string: true,
                                     default_value: ENV["FASTLANE_PASSWORD"],
-                                    optional: false,
+                                    optional: true,
                                     ),
 
           FastlaneCore::ConfigItem.new(key: :altool_output_format,

--- a/lib/fastlane/plugin/altool/actions/altool_action.rb
+++ b/lib/fastlane/plugin/altool/actions/altool_action.rb
@@ -12,8 +12,11 @@ module Fastlane
         altool_app_type = params[:altool_app_type]
         altool_ipa_path = params[:altool_ipa_path]
         altool_username = params[:altool_username]
-        altool_password = params[:altool_password]
         altool_output_format = params[:altool_output_format]
+
+        ENV["ALTOOL_PASSWORD"] = params[:altool_password]
+        altool_password = "@env:ALTOOL_PASSWORD"
+
         UI.message("========Validating and Uploading your ipa file to iTunes Connect=========")
         command = [
           ALTOOL,


### PR DESCRIPTION
From `altool -h`:

```
-p, --password
Password. Required if username specified.  Password is read from stdin if one is not supplied.
May use @keychain: or @env: prefixes followed by the keychain or environment variable lookup name.
e.g. -p @env:SECRET which would use the value in the SECRET environment variable.
```