### PR TITLE
Minor capitalization correction for GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This might print the username and password to build console in the commands, pip
 
 ## Example Project Repo
 
-This is a example project [Altool-Demo](https://github.com/Shashikant86/Altool-Demo) available on Github which has its own README.
+This is a example project [Altool-Demo](https://github.com/Shashikant86/Altool-Demo) available on GitHub which has its own README.
 
 ## Run tests for this plugin
 


### PR DESCRIPTION
GitHub uses a capital 'H' 🤓
https://github.com
![](https://cloud.githubusercontent.com/assets/49038/26196161/fa47fb1a-3bb5-11e7-978f-29c4af682648.png)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
