### PR TITLE
Fix for Issue 'altool fails when ipa path contains a space'

### DIFF
--- a/lib/fastlane/plugin/altool/actions/altool_action.rb
+++ b/lib/fastlane/plugin/altool/actions/altool_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         UI.message(" ----altool binary exists on your machine----- ")
 
         altool_app_type = params[:altool_app_type]
-        altool_ipa_path = params[:altool_ipa_path]
+        altool_ipa_path = "\"#{params[:altool_ipa_path]}\""
         altool_username = params[:altool_username]
         altool_output_format = params[:altool_output_format]
 

--- a/lib/fastlane/plugin/altool/version.rb
+++ b/lib/fastlane/plugin/altool/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Altool
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Fix for issue: 
altool fails when ipa path contains a space https://github.com/XCTEQ/fastlane-plugin-altool/issues/4